### PR TITLE
Setter issuer_name i appen

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -14,7 +14,7 @@ no.nav.security.jwt {
     expirythreshold = 2 #threshold in minutes until token expires
     issuers = [
         {
-            issuer_name = ${?OIDC_ISSUER}
+            issuer_name = "selvbetjening"
             discoveryurl = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
             accepted_audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
             cookie_name = selvbetjening-idtoken


### PR DESCRIPTION
I dette tilfellet er issuer_name bare et kallenavn eller en referanse som gjør det lett for oss å skille mellom issuerne på, men vi må sende den inn i og med tokensupport forventer dette.

Fyi, issuer_name var i Vault før, men jeg hadde tatt den bort og derfor gikk appen i `CrashLoopBackOff` i dev 😅 